### PR TITLE
Centralize firebase config

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,8 @@
   <link rel="stylesheet" href="/css/style.css">
   <link rel="manifest" href="/manifest.json">
   <script type="module">
-    import { app, analytics } from './js/firebaseConfig.js';
+    import './js/firebaseConfig.js';
     // Ensure Firebase initializes when the page loads
-    void app;
-    void analytics;
   </script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.4.4/build/qrcode.min.js"></script>
 </head>

--- a/index.html
+++ b/index.html
@@ -7,22 +7,10 @@
   <link rel="stylesheet" href="/css/style.css">
   <link rel="manifest" href="/manifest.json">
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js';
-    import { getAnalytics } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-analytics.js';
-    import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-auth.js';
-    import { getDatabase } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-database.js';
-    const firebaseConfig = {
-      apiKey: "AIzaSyAPPllpKiFOcjqxnuk2tRvithFYKSzkQAc",
-      authDomain: "smarthubultra.firebaseapp.com",
-      databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
-      projectId: "smarthubultra",
-      storageBucket: "smarthubultra.firebasestorage.app",
-      messagingSenderId: "12039705608",
-      appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
-      measurementId: "G-V24P3DHL9M"
-    };
-    const app = initializeApp(firebaseConfig);
-    getAnalytics(app);
+    import { app, analytics } from './js/firebaseConfig.js';
+    // Ensure Firebase initializes when the page loads
+    void app;
+    void analytics;
   </script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.4.4/build/qrcode.min.js"></script>
 </head>

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,22 +1,10 @@
 import { showToast, speak, logActivity, closeAllModals } from './utils.js';
 import { loadDashboard } from './dashboard.js';
 import { startHoloGuide } from './holoGuide.js';
-import { initializeApp } from 'firebase/app';
 import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, sendPasswordResetEmail } from 'firebase/auth';
 import { getDatabase, ref, set, get } from 'firebase/database';
+import { app } from './firebaseConfig.js';
 
-const firebaseConfig = {
-  apiKey: "AIzaSyAPPllpKiFOcjqxnuk2tRvithFYKSzkQAc",
-  authDomain: "smarthubultra.firebaseapp.com",
-  databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
-  projectId: "smarthubultra",
-  storageBucket: "smarthubultra.firebasestorage.app",
-  messagingSenderId: "12039705608",
-  appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
-  measurementId: "G-V24P3DHL9M"
-};
-
-const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const database = getDatabase(app);
 

--- a/js/bots.js
+++ b/js/bots.js
@@ -7,9 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link rel="manifest" href="/manifest.json">
   <script type="module">
-    import { app, analytics } from './firebaseConfig.js';
-    void app;
-    void analytics;
+    import './firebaseConfig.js';
   </script>
 </head>
 <body>

--- a/js/bots.js
+++ b/js/bots.js
@@ -7,22 +7,9 @@
   <link rel="stylesheet" href="/css/style.css">
   <link rel="manifest" href="/manifest.json">
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js';
-    import { getAnalytics } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-analytics.js';
-    import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-auth.js';
-    import { getDatabase } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-database.js';
-    const firebaseConfig = {
-      apiKey: "AIzaSyAPPllpKiFOcjqxnuk2tRvithFYKSzkQAc",
-      authDomain: "smarthubultra.firebaseapp.com",
-      databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
-      projectId: "smarthubultra",
-      storageBucket: "smarthubultra.firebasestorage.app",
-      messagingSenderId: "12039705608",
-      appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
-      measurementId: "G-V24P3DHL9M"
-    };
-    const app = initializeApp(firebaseConfig);
-    getAnalytics(app);
+    import { app, analytics } from './firebaseConfig.js';
+    void app;
+    void analytics;
   </script>
 </head>
 <body>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -7,9 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link rel="manifest" href="/manifest.json">
   <script type="module">
-    import { app, analytics } from './firebaseConfig.js';
-    void app;
-    void analytics;
+    import './firebaseConfig.js';
   </script>
 </head>
 <body>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -7,22 +7,9 @@
   <link rel="stylesheet" href="/css/style.css">
   <link rel="manifest" href="/manifest.json">
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js';
-    import { getAnalytics } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-analytics.js';
-    import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-auth.js';
-    import { getDatabase } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-database.js';
-    const firebaseConfig = {
-      apiKey: "AIzaSyAPPllpKiFOcjqxnuk2tRvithFYKSzkQAc",
-      authDomain: "smarthubultra.firebaseapp.com",
-      databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
-      projectId: "smarthubultra",
-      storageBucket: "smarthubultra.firebasestorage.app",
-      messagingSenderId: "12039705608",
-      appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
-      measurementId: "G-V24P3DHL9M"
-    };
-    const app = initializeApp(firebaseConfig);
-    getAnalytics(app);
+    import { app, analytics } from './firebaseConfig.js';
+    void app;
+    void analytics;
   </script>
 </head>
 <body>

--- a/js/firebaseConfig.js
+++ b/js/firebaseConfig.js
@@ -1,0 +1,18 @@
+import { initializeApp } from 'firebase/app';
+import { getAnalytics } from 'firebase/analytics';
+
+const firebaseConfig = {
+  apiKey: "AIzaSyAPPllpKiFOcjqxnuk2tRvithFYKSzkQAc",
+  authDomain: "smarthubultra.firebaseapp.com",
+  databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
+  projectId: "smarthubultra",
+  storageBucket: "smarthubultra.firebasestorage.app",
+  messagingSenderId: "12039705608",
+  appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
+  measurementId: "G-V24P3DHL9M"
+};
+
+const app = initializeApp(firebaseConfig);
+const analytics = getAnalytics(app);
+
+export { app, analytics, firebaseConfig };

--- a/js/firebaseConfig.js
+++ b/js/firebaseConfig.js
@@ -2,14 +2,14 @@ import { initializeApp } from 'firebase/app';
 import { getAnalytics } from 'firebase/analytics';
 
 const firebaseConfig = {
-  apiKey: "AIzaSyAPPllpKiFOcjqxnuk2tRvithFYKSzkQAc",
-  authDomain: "smarthubultra.firebaseapp.com",
-  databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
-  projectId: "smarthubultra",
-  storageBucket: "smarthubultra.firebasestorage.app",
-  messagingSenderId: "12039705608",
-  appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
-  measurementId: "G-V24P3DHL9M"
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  databaseURL: import.meta.env.VITE_FIREBASE_DATABASE_URL,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID
 };
 
 const app = initializeApp(firebaseConfig);

--- a/js/firebaseConfig.js
+++ b/js/firebaseConfig.js
@@ -1,6 +1,18 @@
+/**
+ * Firebase Configuration Module
+ * 
+ * Centralizes Firebase initialization and exports Firebase instances
+ * for use throughout the application.
+ * 
+ * @module firebaseConfig
+ */
 import { initializeApp } from 'firebase/app';
 import { getAnalytics } from 'firebase/analytics';
 
+/**
+ * Firebase configuration object with environment-based credentials.
+ * @type {import('firebase/app').FirebaseOptions}
+ */
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
@@ -12,7 +24,16 @@ const firebaseConfig = {
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID
 };
 
+/**
+ * The initialized Firebase app instance.
+ * @type {import('firebase/app').FirebaseApp}
+ */
 const app = initializeApp(firebaseConfig);
+
+/**
+ * The Firebase analytics instance.
+ * @type {import('firebase/analytics').Analytics}
+ */
 const analytics = getAnalytics(app);
 
 export { app, analytics, firebaseConfig };

--- a/js/main.js
+++ b/js/main.js
@@ -1,20 +1,6 @@
-import { initializeApp } from 'firebase/app';
-import { getAnalytics, logEvent } from 'firebase/analytics';
+import { logEvent } from 'firebase/analytics';
 import { showToast } from './utils.js';
-
-const firebaseConfig = {
-  apiKey: "AIzaSyAPPllpKiFOcjqxnuk2tRvithFYKSzkQAc",
-  authDomain: "smarthubultra.firebaseapp.com",
-  databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
-  projectId: "smarthubultra",
-  storageBucket: "smarthubultra.firebasestorage.app",
-  messagingSenderId: "12039705608",
-  appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
-  measurementId: "G-V24P3DHL9M"
-};
-
-const app = initializeApp(firebaseConfig);
-const analytics = getAnalytics(app);
+import { app, analytics } from './firebaseConfig.js';
 
 async function init() {
   try {

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 import { logEvent } from 'firebase/analytics';
 import { showToast } from './utils.js';
-import { app, analytics } from './firebaseConfig.js';
+import { analytics } from './firebaseConfig.js';
 
 async function init() {
   try {


### PR DESCRIPTION
## Summary
- add `js/firebaseConfig.js` to hold Firebase setup
- use the new module in the main index and pages
- remove inline Firebase configs from scripts

## Testing
- `npm test` *(fails: could not find package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6852f428b71c832aa7bde65fe34c025f)