### PR TITLE
Add code-based reference flow to replace login page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -292,6 +292,143 @@ label {
   gap: 1.8rem;
 }
 
+.code-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.code-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 18px 42px rgba(10, 12, 40, 0.5);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  background: linear-gradient(135deg, rgba(94, 123, 255, 0.42), rgba(66, 240, 193, 0.42));
+  color: var(--tone-strong);
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.badge-soft {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.microcopy {
+  color: var(--tone-soft);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.code-status {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.code-display {
+  background: var(--surface-panel-strong);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  box-shadow: var(--glow-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.code-display__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.code-display__value {
+  font-family: var(--mono-stack);
+  font-size: clamp(2rem, 6vw, 3.2rem);
+  letter-spacing: 0.14em;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  text-align: center;
+}
+
+.history-panel {
+  background: var(--surface-panel);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.history-item {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.history-item.active {
+  border-color: rgba(94, 123, 255, 0.7);
+  box-shadow: 0 14px 32px rgba(94, 123, 255, 0.24);
+}
+
+.history-item__title {
+  font-weight: 700;
+}
+
+.history-item__meta {
+  color: var(--tone-soft);
+  font-size: 0.9rem;
+}
+
+.ghost {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
 .auth-panel h2 {
   margin: 0;
   font-size: 1.9rem;

--- a/index.html
+++ b/index.html
@@ -3,10 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Smart Hub Ultra - Sign In</title>
+  <title>Smart Hub Ultra - User Code Reference</title>
   <link rel="stylesheet" href="./css/style.css">
   <link rel="manifest" href="./manifest.json">
-  <!-- Firebase is initialized from modules inside /js/main.js so bundlers resolve the 'firebase' package from node_modules -->
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.4.4/build/qrcode.min.js"></script>
 </head>
 <body>
@@ -24,122 +23,98 @@
     </div>
   </header>
 
-  <main id="auth-page" class="page">
+  <main id="code-page" class="page">
     <div class="page-content">
       <section class="auth-hero">
         <div class="auth-hero__intro">
           <div class="pillar-pills">
-            <span class="pill">Passwordless</span>
-            <span class="pill">Project Codes</span>
-            <span class="pill">Executive Channel</span>
+            <span class="pill">Code-first access</span>
+            <span class="pill">No logins</span>
+            <span class="pill">Builder recall</span>
           </div>
-          <h1>Command your intelligent creative universe</h1>
-          <p>Launch new ideas instantly, resume with a single project code, and invite collaborators with enterprise-grade guardrails. Smart Hub Ultra adapts in real-time so every session feels alive.</p>
+          <h1>Return to any build with a single code</h1>
+          <p>Generate a 6-digit reference code and a 4-16 character username to anchor every build session. Share the code with teammates or keep it private—no password walls, just direct access back to your activity.</p>
           <div id="vibe-quiz-container"></div>
           <div class="feature-grid">
             <article class="feature-card">
-              <span class="cue">Instant entry</span>
-              <h3>Project sessions spin up in seconds</h3>
-              <p>Create a shareable code the moment inspiration strikes. No approval queue, no password hurdles.</p>
+              <span class="cue">Rapid start</span>
+              <h3>Spin up a reference in seconds</h3>
+              <p>Create a username, lock in a numeric code, and jump right back into your build when you return.</p>
             </article>
             <article class="feature-card">
-              <span class="cue">Intelligent orchestration</span>
-              <h3>Situation-aware dashboards</h3>
-              <p>Adaptive widgets surface insights, predictive nudges, and context-aware actions for every role.</p>
+              <span class="cue">Session recall</span>
+              <h3>Resume without friction</h3>
+              <p>Paste your code to reopen your page or activity builds instantly. We keep your last touches visible.</p>
             </article>
             <article class="feature-card">
-              <span class="cue">Executive fast pass</span>
-              <h3>Authorize and escalate securely</h3>
-              <p>Custom-claim upgrades, transactional invites, and scheduled cleanup keep access sharp and safe.</p>
+              <span class="cue">Team-friendly</span>
+              <h3>Shareable, auditable markers</h3>
+              <p>Reference cards capture usernames, timestamps, and recency so teams can align fast.</p>
             </article>
           </div>
         </div>
 
         <div class="glass-panel auth-panel">
           <div>
-            <h2>Access Smart Hub Ultra</h2>
-            <p style="margin:0;color:var(--tone-soft);font-size:0.95rem;">Choose the path that fits your moment—magic links, project codes, guest sessions, or executive overrides.</p>
+            <h2>User Code Reference</h2>
+            <p style="margin:0;color:var(--tone-soft);font-size:0.95rem;">Create a numeric reference code and username for every build. Reuse the code anytime to return to your page or activity stream.</p>
           </div>
 
-          <form id="sign-up-form">
-            <input type="email" id="sign-up-email" placeholder="Email" required>
-            <input type="text" id="sign-up-username" placeholder="Username (optional)">
-            <label>We'll send a secure sign-in link to your email. No passwords required.</label>
-            <div style="display:flex;flex-wrap:wrap;gap:10px;align-items:center;">
-              <button id="send-signin-link" type="button">Send Sign-in Link</button>
-              <button type="submit">Send &amp; Create Account</button>
-            </div>
-          </form>
-
-          <form id="sign-in-form">
-            <input type="email" id="sign-in-email" placeholder="Email" required>
-            <button type="submit">Sign In (email link)</button>
-            <a href="#" id="forgot-password" style="font-size:0.82rem;color:var(--tone-muted);">Resend sign-in link</a>
-          </form>
-
-          <div id="magic-link-fallback" class="auth-fallback hidden">
-            <p class="auth-fallback__title">Instant magic link</p>
-            <p id="magic-link-meta" class="auth-fallback__meta"></p>
-            <div class="auth-fallback__field">
-              <input id="magic-link-url" type="text" readonly>
-              <button id="magic-link-copy" type="button">Copy</button>
-            </div>
-          </div>
-
-          <div class="auth-quick-actions">
-            <button id="project-session-btn" type="button">Start New Project Session</button>
-            <button id="guest-login-btn" type="button">Continue as Guest</button>
-            <button id="admin-fast-login-btn" type="button">Executive Fast Login</button>
-          </div>
-
-          <div id="project-code-panel" class="auth-fallback hidden">
-            <p class="auth-fallback__title">Your project code</p>
-            <p id="project-code-meta" class="auth-fallback__meta"></p>
-            <div class="auth-fallback__field">
-              <input id="project-code-value" type="text" readonly>
-              <button id="project-code-copy" type="button">Copy</button>
-            </div>
-          </div>
-
-          <form id="project-code-form">
-            <h3 style="margin:0;">Resume with Project Code</h3>
-            <input type="text" id="project-code-input" placeholder="Enter your project code" required maxlength="8" pattern="[A-Z0-9]{6,8}">
-            <button type="submit">Resume Session</button>
-            <label>Enter the project code you received earlier to pick up where you left off.</label>
-          </form>
-
-          <section class="auth-invite">
-            <h3>Invite a collaborator</h3>
-            <form id="invite-collab-form">
-              <input type="email" id="invite-email" placeholder="Their email" required>
-              <select id="invite-role">
-                <option value="user" selected>Standard user</option>
-                <option value="guest">Guest</option>
-                <option value="admin">Admin (executive)</option>
-              </select>
-              <button type="submit">Generate invite link</button>
-            </form>
-            <div id="invite-link-output" class="auth-fallback hidden">
-              <p class="auth-fallback__title">Share this invite link</p>
-              <p id="invite-link-meta" class="auth-fallback__meta"></p>
-              <div class="auth-fallback__field">
-                <input id="invite-link-url" type="text" readonly>
-                <button id="invite-link-copy" type="button">Copy</button>
+          <div class="code-grid">
+            <section class="code-card">
+              <div class="card-header">
+                <div>
+                  <p class="cue">Start a build</p>
+                  <h3 style="margin:4px 0 0;">Generate code + username</h3>
+                </div>
+                <span class="badge">6-digit code</span>
               </div>
+              <label for="username-input">Username (4-16 characters)</label>
+              <input id="username-input" type="text" minlength="4" maxlength="16" placeholder="e.g. OrbitMaker" autocomplete="off" required>
+              <button id="start-build-btn" type="button">Create reference</button>
+              <p class="microcopy">We pair your username with a unique 6-digit number. Keep it to resume this build later.</p>
+            </section>
+
+            <section class="code-card">
+              <div class="card-header">
+                <div>
+                  <p class="cue">Return to a build</p>
+                  <h3 style="margin:4px 0 0;">Use an existing code</h3>
+                </div>
+                <span class="badge badge-soft">Resume</span>
+              </div>
+              <form id="resume-form">
+                <label for="resume-code-input">Reference code</label>
+                <input id="resume-code-input" type="text" inputmode="numeric" pattern="\d{6}" placeholder="123456" maxlength="6" required>
+                <button type="submit">Find my build</button>
+              </form>
+              <p class="microcopy">Paste the 6-digit code from your build card. We pull the matching username and history.</p>
+            </section>
+          </div>
+
+          <section class="code-status">
+            <div class="code-display" id="active-code">
+              <div class="code-display__header">
+                <div>
+                  <p class="cue">Active reference</p>
+                  <h3 id="active-username">No code selected</h3>
+                </div>
+                <button id="copy-code-btn" type="button" class="ghost">Copy code</button>
+              </div>
+              <div class="code-display__value" id="active-code-value">------</div>
+              <p class="microcopy" id="active-code-meta">Create or resume a build to see details here.</p>
+            </div>
+            <div class="history-panel">
+              <div class="history-header">
+                <div>
+                  <p class="cue">Recent references</p>
+                  <h3 style="margin:4px 0 0;">Saved build codes</h3>
+                </div>
+                <button id="clear-history-btn" type="button" class="ghost">Clear list</button>
+              </div>
+              <div id="code-history" class="history-list"></div>
             </div>
           </section>
-
-          <form id="support-form" class="support-grid">
-            <div style="display:flex;flex-direction:column;gap:0.75rem;">
-              <label for="support-email">Support email</label>
-              <input type="email" id="support-email" placeholder="Email" required>
-            </div>
-            <div style="display:flex;flex-direction:column;gap:0.75rem;">
-              <label for="support-message">How can we help?</label>
-              <textarea id="support-message" placeholder="Describe your issue" required></textarea>
-              <button type="submit">Submit Support Ticket</button>
-            </div>
-          </form>
         </div>
       </section>
 
@@ -175,18 +150,16 @@
       <span>Designed for builders who think in light speed.</span>
     </div>
   </footer>
-  <!-- Firebase compatibility shim (creates window.firebase for legacy modules) -->
   <script type="module" src="./js/firebase-compat.js"></script>
   <script src="./js/main.js" type="module"></script>
   <script type="module">
     import { mountVibeQuiz } from './js/vibeQuiz.js';
-    import { loadAuth } from './js/auth.js';
-    
-    // Initialize components when DOM is ready
+    import { loadCodeReference } from './js/codeReference.js';
+
     document.addEventListener('DOMContentLoaded', async () => {
       try {
         mountVibeQuiz('vibe-quiz-container');
-        await loadAuth();
+        await loadCodeReference();
       } catch (error) {
         console.error('Component initialization error:', error);
       }

--- a/js/codeReference.js
+++ b/js/codeReference.js
@@ -1,0 +1,214 @@
+import { showToast } from './utils.js';
+
+const STORAGE_KEY = 'shuUserCodes';
+const ACTIVE_KEY = 'shuActiveUserCode';
+
+function generateNumericCode() {
+  return Math.floor(100000 + Math.random() * 900000).toString();
+}
+
+function sanitizeUsername(value = '') {
+  return value.trim();
+}
+
+function isValidUsername(value) {
+  return /^[A-Za-z0-9_-]{4,16}$/.test(value);
+}
+
+function loadSavedCodes() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (err) {
+    console.warn('Failed to parse saved codes', err);
+    return [];
+  }
+}
+
+function persistCodes(codes = []) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(codes));
+}
+
+function formatTimestamp(ts) {
+  return new Date(ts).toLocaleString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    month: 'short',
+    day: 'numeric'
+  });
+}
+
+function renderActivePanel(entry) {
+  const usernameEl = document.getElementById('active-username');
+  const codeValueEl = document.getElementById('active-code-value');
+  const metaEl = document.getElementById('active-code-meta');
+  const copyBtn = document.getElementById('copy-code-btn');
+
+  if (!entry) {
+    if (usernameEl) usernameEl.textContent = 'No code selected';
+    if (codeValueEl) codeValueEl.textContent = '------';
+    if (metaEl) metaEl.textContent = 'Create or resume a build to see details here.';
+    if (copyBtn) copyBtn.disabled = true;
+    return;
+  }
+
+  if (usernameEl) usernameEl.textContent = entry.username;
+  if (codeValueEl) codeValueEl.textContent = entry.code;
+  if (metaEl) metaEl.textContent = `Created ${formatTimestamp(entry.createdAt)} • Last opened ${formatTimestamp(entry.updatedAt || entry.createdAt)}`;
+  if (copyBtn) {
+    copyBtn.disabled = false;
+    copyBtn.onclick = async () => {
+      try {
+        await navigator.clipboard.writeText(entry.code);
+        showToast('Code copied');
+      } catch (err) {
+        console.warn('Clipboard unavailable', err);
+        showToast('Copy not available in this browser');
+      }
+    };
+  }
+}
+
+function renderHistory(codes = [], activeCode = null) {
+  const container = document.getElementById('code-history');
+  if (!container) return;
+  container.innerHTML = '';
+
+  if (!codes.length) {
+    const empty = document.createElement('p');
+    empty.className = 'microcopy';
+    empty.textContent = 'Your saved references will appear here.';
+    container.appendChild(empty);
+    return;
+  }
+
+  codes
+    .sort((a, b) => (b.updatedAt || b.createdAt) - (a.updatedAt || a.createdAt))
+    .forEach((entry) => {
+      const item = document.createElement('div');
+      item.className = 'history-item';
+      if (entry.code === activeCode) item.classList.add('active');
+
+      const title = document.createElement('div');
+      title.className = 'history-item__title';
+      title.textContent = `${entry.username}`;
+
+      const meta = document.createElement('div');
+      meta.className = 'history-item__meta';
+      meta.textContent = `${entry.code} • updated ${formatTimestamp(entry.updatedAt || entry.createdAt)}`;
+
+      const action = document.createElement('button');
+      action.type = 'button';
+      action.className = 'ghost';
+      action.textContent = entry.code === activeCode ? 'Active' : 'Open';
+      action.disabled = entry.code === activeCode;
+      action.addEventListener('click', () => {
+        setActiveCode(entry);
+        showToast('Reference opened');
+      });
+
+      item.appendChild(title);
+      item.appendChild(meta);
+      item.appendChild(action);
+      container.appendChild(item);
+    });
+}
+
+function setActiveCode(entry) {
+  if (!entry) return;
+  const codes = loadSavedCodes();
+  const updated = codes.map((item) => (item.code === entry.code ? { ...item, updatedAt: Date.now() } : item));
+  persistCodes(updated);
+  localStorage.setItem(ACTIVE_KEY, entry.code);
+  renderActivePanel({ ...entry, updatedAt: Date.now() });
+  renderHistory(updated, entry.code);
+}
+
+function handleStartBuild(usernameInput) {
+  const username = sanitizeUsername(usernameInput?.value || '');
+  if (!username) {
+    showToast('Enter a username to generate a code');
+    return;
+  }
+  if (!isValidUsername(username)) {
+    showToast('Username must be 4-16 characters (letters, numbers, _ or -)');
+    return;
+  }
+
+  const code = generateNumericCode();
+  const now = Date.now();
+  const entry = { code, username, createdAt: now, updatedAt: now };
+
+  const codes = loadSavedCodes();
+  codes.push(entry);
+  persistCodes(codes);
+  localStorage.setItem(ACTIVE_KEY, code);
+
+  renderActivePanel(entry);
+  renderHistory(codes, code);
+  if (usernameInput) usernameInput.value = '';
+  showToast(`Reference ready: ${code}`);
+}
+
+function handleResume(form) {
+  const input = document.getElementById('resume-code-input');
+  if (!input) return;
+  const raw = (input.value || '').trim();
+  const code = raw.replace(/\D/g, '').slice(0, 6);
+  input.value = code;
+
+  if (!/^\d{6}$/.test(code)) {
+    showToast('Enter a 6-digit code');
+    return;
+  }
+
+  const codes = loadSavedCodes();
+  const match = codes.find((item) => item.code === code);
+  if (!match) {
+    showToast('Code not found. Generate a new reference.');
+    return;
+  }
+
+  setActiveCode(match);
+  form?.reset();
+  showToast('Reference restored');
+}
+
+function wireClearHistory() {
+  const clearBtn = document.getElementById('clear-history-btn');
+  if (!clearBtn) return;
+  clearBtn.addEventListener('click', () => {
+    persistCodes([]);
+    localStorage.removeItem(ACTIVE_KEY);
+    renderActivePanel(null);
+    renderHistory([], null);
+    showToast('History cleared');
+  });
+}
+
+export async function loadCodeReference() {
+  const usernameInput = document.getElementById('username-input');
+  const startBtn = document.getElementById('start-build-btn');
+  const resumeForm = document.getElementById('resume-form');
+
+  const savedCodes = loadSavedCodes();
+  const activeCode = localStorage.getItem(ACTIVE_KEY);
+  const activeEntry = savedCodes.find((item) => item.code === activeCode) || savedCodes[0] || null;
+
+  renderActivePanel(activeEntry);
+  renderHistory(savedCodes, activeEntry?.code || null);
+  wireClearHistory();
+
+  if (startBtn) {
+    startBtn.addEventListener('click', () => handleStartBuild(usernameInput));
+  }
+
+  if (resumeForm) {
+    resumeForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      handleResume(resumeForm);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- replace the old sign-in landing with a code-based reference experience for builds
- add UI for generating 6-digit codes with usernames and viewing active/history panels
- implement a new codeReference module to persist and recall references locally

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938d7db95b0832a8493381d1b022eeb)