### PR TITLE
Add notification dropdown container

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -49,7 +49,9 @@
         <a href="/ar" class="nav-link">AR Mode</a>
         <button id="predictive-btn">Predictive Tasks</button>
       </div>
-      <div id="notification-list"></div>
+      <div id="notification-dropdown" class="hidden">
+        <div id="notification-list"></div>
+      </div>
       <span id="notification-count" class="hidden"></span>
       <button id="notification-icon">Notifications</button>
     </div>


### PR DESCRIPTION
## Summary
- add missing container for notifications dropdown in dashboard page

## Testing
- `node --version`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6852f3c258b0832a948fe7dc77c9d49a)