### PR TITLE
Fix bucket name

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const firebaseConfig = {
   authDomain: "YOUR_AUTH_DOMAIN",
   databaseURL: "YOUR_DATABASE_URL",
   projectId: "YOUR_PROJECT_ID",
-  storageBucket: "YOUR_STORAGE_BUCKET",
+  storageBucket: "smarthubultra.appspot.com",
   messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
   appId: "YOUR_APP_ID"
 };

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       authDomain: "smarthubultra.firebaseapp.com",
       databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
       projectId: "smarthubultra",
-      storageBucket: "smarthubultra.firebasestorage.app",
+      storageBucket: "smarthubultra.appspot.com",
       messagingSenderId: "12039705608",
       appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
       measurementId: "G-V24P3DHL9M"

--- a/js/auth.js
+++ b/js/auth.js
@@ -10,7 +10,7 @@ const firebaseConfig = {
   authDomain: "smarthubultra.firebaseapp.com",
   databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
   projectId: "smarthubultra",
-  storageBucket: "smarthubultra.firebasestorage.app",
+  storageBucket: "smarthubultra.appspot.com",
   messagingSenderId: "12039705608",
   appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
   measurementId: "G-V24P3DHL9M"

--- a/js/bots.js
+++ b/js/bots.js
@@ -16,7 +16,7 @@
       authDomain: "smarthubultra.firebaseapp.com",
       databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
       projectId: "smarthubultra",
-      storageBucket: "smarthubultra.firebasestorage.app",
+      storageBucket: "smarthubultra.appspot.com",
       messagingSenderId: "12039705608",
       appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
       measurementId: "G-V24P3DHL9M"

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -16,7 +16,7 @@
       authDomain: "smarthubultra.firebaseapp.com",
       databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
       projectId: "smarthubultra",
-      storageBucket: "smarthubultra.firebasestorage.app",
+      storageBucket: "smarthubultra.appspot.com",
       messagingSenderId: "12039705608",
       appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
       measurementId: "G-V24P3DHL9M"

--- a/js/main.js
+++ b/js/main.js
@@ -7,7 +7,7 @@ const firebaseConfig = {
   authDomain: "smarthubultra.firebaseapp.com",
   databaseURL: "https://smarthubultra-default-rtdb.firebaseio.com",
   projectId: "smarthubultra",
-  storageBucket: "smarthubultra.firebasestorage.app",
+  storageBucket: "smarthubultra.appspot.com",
   messagingSenderId: "12039705608",
   appId: "1:12039705608:web:f1a4383b245275eaa26dbd",
   measurementId: "G-V24P3DHL9M"


### PR DESCRIPTION
## Summary
- use `smarthubultra.appspot.com` in all Firebase config definitions

## Testing
- `curl -I https://smarthubultra.appspot.com`
- `curl -I https://smarthubultra.firebasestorage.app`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6852f282d144832aa72064b2a3af697d)