### PR TITLE
Refactor Firebase database usage

### DIFF
--- a/js/account.js
+++ b/js/account.js
@@ -1,8 +1,11 @@
 import { IDB, showToast, speak, logActivity, closeAllModals } from './utils.js';
 import { setupTelegramNotifications } from './notifications.js';
+import { getDatabase, ref, update } from 'firebase/database';
+import { app } from './main.js';
 
 export async function loadAccount() {
   try {
+    const database = getDatabase(app);
     const user = await IDB.get('users', localStorage.getItem('currentUser'));
     document.getElementById('account-username').textContent = user.username || 'N/A';
     document.getElementById('account-email').textContent = user.email;
@@ -18,7 +21,7 @@ export async function loadAccount() {
       document.getElementById('profile-pic').src = url;
       user.profilePic = url;
       await IDB.batchSet('users', [user]);
-      firebase.database().ref('users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')).update({ profilePic: url });
+      await update(ref(database, 'users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')), { profilePic: url });
       showToast('Profile picture updated');
       logActivity('Updated profile picture');
     });
@@ -36,7 +39,7 @@ export async function loadAccount() {
       user.fourDigit = fourDigit;
       user.passwordChanges.push({ oldPassword: user.password, newPassword, timestamp: Date.now() });
       await IDB.batchSet('users', [user]);
-      firebase.database().ref('users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')).update(user);
+      await update(ref(database, 'users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')), user);
       showToast('Credentials updated');
       logActivity('Updated account credentials');
     });
@@ -47,7 +50,7 @@ export async function loadAccount() {
       document.getElementById('telegram-chat-id').value = chatId;
       user.telegramChatId = chatId;
       await IDB.batchSet('users', [user]);
-      firebase.database().ref('users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')).update({ telegramChatId: chatId });
+      await update(ref(database, 'users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')), { telegramChatId: chatId });
       showToast('Telegram Chat ID fetched');
       logActivity('Fetched Telegram Chat ID');
     });
@@ -59,7 +62,7 @@ export async function loadAccount() {
       document.body.style.background = theme.image ? `url(${theme.image})` : theme.color;
       user.theme = theme;
       await IDB.batchSet('users', [user]);
-      firebase.database().ref('users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')).update({ theme });
+      await update(ref(database, 'users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')), { theme });
       showToast('Theme applied');
       logActivity('Applied custom theme');
     });
@@ -80,7 +83,7 @@ export async function loadAccount() {
     document.getElementById('enable-narration').addEventListener('change', e => {
       user.narration = e.target.checked;
       IDB.batchSet('users', [user]);
-      firebase.database().ref('users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')).update({ narration: e.target.checked });
+      update(ref(database, 'users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')), { narration: e.target.checked });
       showToast(`AI narration ${e.target.checked ? 'enabled' : 'disabled'}`);
     });
 
@@ -93,7 +96,7 @@ export async function loadAccount() {
     document.getElementById('ar-mode').addEventListener('change', e => {
       user.arMode = e.target.checked;
       IDB.batchSet('users', [user]);
-      firebase.database().ref('users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')).update({ arMode: e.target.checked });
+      update(ref(database, 'users/' + user.email.replace(/[^a-zA-Z0-9]/g, '')), { arMode: e.target.checked });
       showToast(`AR mode ${e.target.checked ? 'enabled' : 'disabled'}`);
     });
 

--- a/js/boss.js
+++ b/js/boss.js
@@ -1,7 +1,10 @@
 import { IDB, showToast, speak, logActivity } from './utils.js';
+import { getDatabase, ref, set } from 'firebase/database';
+import { app } from './main.js';
 
 export async function loadBossView() {
   try {
+    const database = getDatabase(app);
     const usersDiv = document.getElementById('boss-users');
     usersDiv.innerHTML = '';
     const users = await IDB.getAll('users');
@@ -53,7 +56,7 @@ export async function loadBossView() {
         timestamp: Date.now()
       };
       await IDB.batchSet('notifications', [notification]);
-      firebase.database().ref('notifications/' + notification.id).set(notification);
+      await set(ref(database, 'notifications/' + notification.id), notification);
       showToast('Announcement broadcasted');
       logActivity(`Broadcasted announcement: ${message}`);
     });

--- a/js/builder.js
+++ b/js/builder.js
@@ -1,9 +1,12 @@
 import { IDB, showToast, speak, logActivity } from './utils.js';
 import { generateBehavioralDNA } from './behavioralDNA.js';
 import { setupCollaborativeMode } from './collab.js';
+import { getDatabase, ref, set } from 'firebase/database';
+import { app } from './main.js';
 
 export function setupBotBuilder() {
   try {
+    const database = getDatabase(app);
     const workspace = document.getElementById('builder-workspace');
     workspace.innerHTML = '';
     const components = document.querySelectorAll('.component');
@@ -46,8 +49,8 @@ export function setupBotBuilder() {
       const dna = generateBehavioralDNA(bot.purpose, bot.code);
       await IDB.batchSet('bots', [bot]);
       await IDB.batchSet('behavioral_dna', [dna]);
-      firebase.database().ref('bots/' + bot.id).set(bot);
-      firebase.database().ref('behavioral_dna/' + dna.botId).set(dna);
+      await set(ref(database, 'bots/' + bot.id), bot);
+      await set(ref(database, 'behavioral_dna/' + dna.botId), dna);
       await setupCollaborativeMode(bot);
       showToast(`Bot ${bot.name} built successfully!`);
       logActivity(`Built bot: ${bot.name}`);

--- a/js/collab.js
+++ b/js/collab.js
@@ -1,7 +1,10 @@
 import { IDB, showToast, speak, logActivity } from './utils.js';
+import { getDatabase, ref, update, onValue, set, onChildAdded } from 'firebase/database';
+import { app } from './main.js';
 
 export async function loadCollabHub() {
   try {
+    const database = getDatabase(app);
     document.getElementById('invite-user').addEventListener('click', async () => {
       const email = document.getElementById('collab-user').value;
       if (!email) {
@@ -17,14 +20,14 @@ export async function loadCollabHub() {
       bot.collaborators = bot.collaborators || [];
       bot.collaborators.push(email);
       await IDB.batchSet('bots', [bot]);
-      firebase.database().ref('bots/' + bot.id).update({ collaborators: bot.collaborators });
+      await update(ref(database, 'bots/' + bot.id), { collaborators: bot.collaborators });
       showToast(`Invited ${email} to collaborate`);
       logActivity(`Invited ${email} to collaborate on bot: ${bot.name}`);
     });
 
     const editor = document.getElementById('collab-editor');
     editor.value = JSON.parse(localStorage.getItem('editingBot') || '{}').code || '';
-    firebase.database().ref('collab/' + localStorage.getItem('currentUser')).on('value', snapshot => {
+    onValue(ref(database, 'collab/' + localStorage.getItem('currentUser')), snapshot => {
       const data = snapshot.val();
       if (data && data.code !== editor.value) {
         editor.value = data.code;
@@ -40,12 +43,12 @@ export async function loadCollabHub() {
         message,
         timestamp: Date.now()
       };
-      firebase.database().ref('chat/' + Date.now()).set(chat);
+      set(ref(database, 'chat/' + Date.now()), chat);
       document.getElementById('chat-input').value = '';
       logActivity(`Sent chat message: ${message}`);
     });
 
-    firebase.database().ref('chat').on('child_added', snapshot => {
+    onChildAdded(ref(database, 'chat'), snapshot => {
       const chat = snapshot.val();
       const messages = document.getElementById('chat-messages');
       const div = document.createElement('div');
@@ -65,9 +68,10 @@ export async function loadCollabHub() {
 
 export async function setupCollaborativeMode(bot) {
   try {
-    firebase.database().ref('collab/' + bot.creator).set({ code: bot.code });
+    const database = getDatabase(app);
+    await set(ref(database, 'collab/' + bot.creator), { code: bot.code });
     bot.collaborators?.forEach(collab => {
-      firebase.database().ref('collab/' + collab).set({ code: bot.code });
+      set(ref(database, 'collab/' + collab), { code: bot.code });
     });
   } catch (error) {
     showToast(`Failed to setup collaborative mode: ${error.message}`);

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,9 +1,12 @@
 import { IDB, showToast, speak, logActivity } from './utils.js';
 import { generateBehavioralDNA, validateBotBehavior } from './behavioralDNA.js';
 import { setupCollaborativeMode } from './collab.js';
+import { getDatabase, ref, set } from 'firebase/database';
+import { app } from './main.js';
 
 export async function loadEditor() {
   try {
+    const database = getDatabase(app);
     const editor = document.getElementById('code-editor');
     const bot = JSON.parse(localStorage.getItem('editingBot') || '{}');
     editor.value = bot.code || 'return async () => "Bot initialized";';
@@ -30,13 +33,13 @@ export async function loadEditor() {
         creator: localStorage.getItem('currentUser')
       };
       await IDB.batchSet('versions', [version]);
-      firebase.database().ref('versions/' + bot.id + '/' + version.timestamp).set(version);
+      await set(ref(database, 'versions/' + bot.id + '/' + version.timestamp), version);
       bot.code = code;
       const dna = generateBehavioralDNA(bot.purpose, bot.code);
       await IDB.batchSet('bots', [bot]);
       await IDB.batchSet('behavioral_dna', [dna]);
-      firebase.database().ref('bots/' + bot.id).set(bot);
-      firebase.database().ref('behavioral_dna/' + dna.botId).set(dna);
+      await set(ref(database, 'bots/' + bot.id), bot);
+      await set(ref(database, 'behavioral_dna/' + dna.botId), dna);
       await setupCollaborativeMode(bot);
       showToast('Version saved!');
       logActivity(`Saved version for bot: ${bot.name}`);

--- a/js/main.js
+++ b/js/main.js
@@ -13,7 +13,7 @@ const firebaseConfig = {
   measurementId: "G-V24P3DHL9M"
 };
 
-const app = initializeApp(firebaseConfig);
+export const app = initializeApp(firebaseConfig);
 const analytics = getAnalytics(app);
 
 async function init() {

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -1,7 +1,10 @@
 import { IDB, showToast, speak, logActivity } from './utils.js';
+import { getDatabase, ref, onChildAdded } from 'firebase/database';
+import { app } from './main.js';
 
 export async function loadNotifications() {
   try {
+    const database = getDatabase(app);
     const notificationList = document.getElementById('notification-list');
     notificationList.innerHTML = '';
     const notifications = await IDB.getAll('notifications');
@@ -17,7 +20,7 @@ export async function loadNotifications() {
       document.getElementById('notification-dropdown').classList.toggle('hidden');
     });
 
-    firebase.database().ref('notifications').on('child_added', async snapshot => {
+    onChildAdded(ref(database, 'notifications'), async snapshot => {
       const notification = snapshot.val();
       notificationList.insertAdjacentHTML('afterbegin', `<div><p>${notification.message} (${new Date(notification.timestamp).toLocaleString()})</p></div>`);
       document.getElementById('notification-count').textContent = (await IDB.getAll('notifications')).length + 1;

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,3 +1,6 @@
+import { getDatabase, ref, set } from 'firebase/database';
+import { app } from './main.js';
+
 export function showToast(message) {
   const toast = document.createElement('div');
   toast.className = 'toast';
@@ -26,7 +29,8 @@ export function logActivity(action) {
     timestamp: Date.now()
   };
   IDB.batchSet('tracking', [log]);
-  firebase.database().ref('tracking/' + log.id).set(log);
+  const database = getDatabase(app);
+  set(ref(database, 'tracking/' + log.id), log);
 }
 
 export const IDB = {


### PR DESCRIPTION
## Summary
- export `app` from main config
- use `getDatabase` and related helpers instead of `firebase.database()`
- update editor, builder, boss, collab, account, notifications, utils modules

## Testing
- `npm test` *(fails: could not find package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6852f2730728832ab0cc15defd3dac38)